### PR TITLE
Submodules use https GitHub urls for improved CI support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "ext/android/sdk"]
 	path = ext/android/sdk
-	url = git@github.com:adjust/android_sdk.git
+	url = https://github.com/adjust/android_sdk.git
 [submodule "ext/ios/sdk"]
 	path = ext/ios/sdk
-	url = git@github.com:adjust/ios_sdk.git
+	url = https://github.com/adjust/ios_sdk.git


### PR DESCRIPTION
Our CI systems (Jenkins) aren't setup to support SSH GitHub urls, which causes them to fail when attempting to checkout the submodules within the adobe_air_sdk repo.

This updates the submodule targets to use the https urls instead, which are GitHubs recommended urls: https://help.github.com/articles/which-remote-url-should-i-use/
